### PR TITLE
Improve code display in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,63 +6,64 @@ The Raspberry Pi + OpenScan Pi Shield can be used to control two independent ste
 ## Setup
 In order to add the OpenScan functionality to an existing raspbian system and understand all the dependencies, here is a full step-by-step list of the setup:
 
-`sudo apt-get update`
-
-`sudo apt-get upgrade`
-
-`mkdir -p /home/pi/shared/ui/data/old_flows && mkdir /home/pi/shared/log`
+```
+sudo apt-get update
+sudo apt-get upgrade
+mkdir -p /home/pi/shared/ui/data/old_flows && mkdir /home/pi/shared/log
+```
 
 ### Dependencies
 
-`sudo apt-get install python3-pip && sudo apt-get install python-pip && sudo apt-get install python-pil`
+```
+sudo apt-get install python3-pip && sudo apt-get install python-pip && sudo apt-get install python-pil
+```
 
 ### PiCamera
+```
+sudo apt-get install python3-picamera && sudo apt-get install python-picamera
+```
 
-`sudo apt-get install python3-picamera && sudo apt-get install python-picamera`
-
-`sudo raspi-config`
-
+```
+sudo raspi-config
+```
 --> interface options --> enable camera
 
 ### Samba
 
 Samba is a fileserver, that allows you to access the Pi's filesystem via network folders. This functionality is optional but comes in quite handy.
 
-`sudo apt-get install samba samba-common-bin`
-
-`sudo nano /etc/samba/smb.conf`
+```
+sudo apt-get install samba samba-common-bin
+```
+```
+sudo nano /etc/samba/smb.conf
+```
 
 Change the following lines:
-
-`	workgroup = WORKGROUP`
-
-`	wins support = yes`
-  
-`	read only = no`
+```
+workgroup = WORKGROUP
+wins support = yes  
+read only = no
+```
 
 Add to the end of the file:
-
-`[PiShare]`
-
-` comment=Raspberry Pi Share`
- 
-` path=/home/pi/shared`
- 
-` browseable=Yes`
- 
-` writeable=Yes`
- 
-` only guest=no`
- 
-` create mask=0777`
- 
-` directory mask=0777`
- 
-` public=yes`
+```
+[PiShare]
+comment=Raspberry Pi Share
+path=/home/pi/shared
+browseable=Yes
+writeable=Yes
+only guest=no
+create mask=0777
+directory mask=0777
+public=yes
+```
 
 Set a network password:
 
-`sudo smbpasswd -a pi`
+```
+sudo smbpasswd -a pi
+```
 
 Now you can access the filesystem of the raspberry pi through your network folder using the username "pi" and the given password.
 
@@ -71,14 +72,15 @@ Now you can access the filesystem of the raspberry pi through your network folde
 GPhoto2 is used to control DSLR cameras, which can be connected via USB. For a list of all supported cameras that can be used within this project see: https://raw.githubusercontent.com/OpenScanEu/OpenScan/master/supported_cameras
 
 For more details see: http://www.gphoto.org/doc/
+```
+sudo apt install libgphoto2-dev
+sudo apt install gphoto2
+```
 
-`sudo apt install libgphoto2-dev `
-
-`sudo apt install gphoto2`
-
-`sudo pip3 install -v gphoto2`
-
-`sudo pip install -v gphoto2`
+```
+sudo pip3 install -v gphoto2
+sudo pip install -v gphoto2
+```
 
 for a list of all supported cameras see: http://www.gphoto.org/doc/remote/
 
@@ -89,61 +91,76 @@ For more details see: https://nodered.org/docs/getting-started/raspberrypi
 
 Install NodeRed:
 
-`bash <(curl -sL https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered)`
+```
+bash <(curl -sL https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered)
+```
 
 Set NodeRed to start automatically on boot:
-
-`sudo systemctl enable nodered.service`
+```
+sudo systemctl enable nodered.service
+```
 
 Time to restart the pi :)
 
-`sudo reboot -h`
+```
+sudo reboot -h
+```
 
 Change the default public folder of NodeRed by running
 
-`sudo nano /home/pi/.node-red/settings.js`
+```
+sudo nano /home/pi/.node-red/settings.js
+```
 
 And uncomment and change the following line (httpStatic:...):
 
-`httpStatic: '/home/pi/shared/',`
+```
+httpStatic: '/home/pi/shared/',
+```
 
 Add the some palettes to NodeRed:
 
-`node-red-stop`
-
-`cd ~/.node-red`
-
-`npm install node-red-dashboard && npm install node-red-contrib-python3-function && npm install node-red-contrib-fs-ops && npm install node-red-contrib-isonline`
+```
+node-red-stop
+cd ~/.node-red
+npm install node-red-dashboard && npm install node-red-contrib-python3-function && npm install node-red-contrib-fs-ops && npm install node-red-contrib-isonline
+```
 
 Download the OpenScan Flow to node-red:
-
-`sudo wget -O /home/pi/.node-red/flows_raspberrypi.json https://raw.githubusercontent.com/OpenScanEu/OpenScan/master/update.json`
+```
+sudo wget -O /home/pi/.node-red/flows_raspberrypi.json https://raw.githubusercontent.com/OpenScanEu/OpenScan/master/update.json
+```
 
 Restart and done :))
 
-`sudo reboot -h`
+```
+sudo reboot -h
+```
 
 After the setup you can access the frontend in your browser by typing: `IP:1880/ui`
 The backend can be reached via `IP:1880`
 
 ### Optional: Change hostname
-
-`sudo raspi-config`
+```
+sudo raspi-config
+```
 
 --> Network Options --> Hostname
 
 Change hostname to OpenScanPi
 
 Adjust the NodeRed Settings by opening
-
-`sudo nano /home/pi/.node-red/settings.js`
+```
+sudo nano /home/pi/.node-red/settings.js
+```
 
 uncomment "flowFile: ..." and change it to:
+```
+flowFile: 'flows_raspberrypi.json',
+```
 
-`flowFile: 'flows_raspberrypi.json',`
-
-After the setup you can access the frontend in your browser by typing: `OpenScanPi:1880/ui`
-The backend can be reached via `OpenScanPi:1880` 
+After the setup you can access the frontend in your browser by typing: `OpenScanPi:1880/ui`  
+The backend can be reached via `OpenScanPi:1880`  
 This works from any device, which is in the same network as the raspberry pi.
 
 If you are logged in to your pi, you can also enter the user interface directly through `localhost:1880/ui`


### PR DESCRIPTION
Display code as code-blocks instead of inline-code style by using three backticks instead of one
Remove leading spaces for the sections "Change the following lines" and "Add to the end of the file"