### PR TITLE
Update Node-RED installer URL to use latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For more details see: https://nodered.org/docs/getting-started/raspberrypi
 Install NodeRed:
 
 ```
-bash <(curl -sL https://github.com/node-red/linux-installers/releases/download/v1.0.0/update-nodejs-and-nodered-deb)
+bash <(curl -sL https://github.com/node-red/linux-installers/releases/latest/download/update-nodejs-and-nodered-deb)
 ```
 
 Set NodeRed to start automatically on boot:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For more details see: https://nodered.org/docs/getting-started/raspberrypi
 Install NodeRed:
 
 ```
-bash <(curl -sL https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered)
+bash <(curl -sL https://github.com/node-red/linux-installers/releases/download/v1.0.0/update-nodejs-and-nodered-deb)
 ```
 
 Set NodeRed to start automatically on boot:


### PR DESCRIPTION
Updates the Node-RED installer URL to use the latest release endpoint instead of the raw file from master branch.

This follows the changes made in https://github.com/node-red/linux-installers/pull/60 where Node-RED moved to using GitHub releases for their installer distribution.

The new URL automatically points to the latest stable version: 
`https://github.com/node-red/linux-installers/releases/latest/download/update-nodejs-and-nodered-deb`